### PR TITLE
Make status events and flag parsing functionality public

### DIFF
--- a/client/status_events.go
+++ b/client/status_events.go
@@ -15,18 +15,18 @@ import (
 	"sync"
 )
 
-// statusEventsConsumer uses a bounded cyclic events queue, safe for concurrent use.
+// StatusEventsConsumer uses a bounded cyclic events queue, safe for concurrent use.
 // When capacity is reached, oldest events in the queue are replaced by newer ones.
-type statusEventsConsumer struct {
+type StatusEventsConsumer struct {
 	buf *ringBuffer
 
 	closed bool
 	cond   *sync.Cond
 }
 
-// newStatusEventsConsumer constructs a new statusEventsConsumer with the given size.
-func newStatusEventsConsumer(size int) *statusEventsConsumer {
-	consumer := &statusEventsConsumer{}
+// NewStatusEventsConsumer constructs a new StatusEventsConsumer with the given size.
+func NewStatusEventsConsumer(size int) *StatusEventsConsumer {
+	consumer := &StatusEventsConsumer{}
 
 	consumer.buf = newRingBuffer(size)
 	consumer.cond = sync.NewCond(&sync.Mutex{})
@@ -35,13 +35,13 @@ func newStatusEventsConsumer(size int) *statusEventsConsumer {
 }
 
 // start event delivery loop.
-func (q *statusEventsConsumer) start(consume func(e interface{})) {
+func (q *StatusEventsConsumer) Start(consume func(e interface{})) {
 	q.closed = false
 	go q.eventLoop(consume)
 }
 
 // stop event delivery loop.
-func (q *statusEventsConsumer) stop() {
+func (q *StatusEventsConsumer) Stop() {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
 
@@ -51,7 +51,7 @@ func (q *statusEventsConsumer) stop() {
 }
 
 // add new event to the queue.
-func (q *statusEventsConsumer) add(e interface{}) {
+func (q *StatusEventsConsumer) Add(e interface{}) {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
 
@@ -60,7 +60,7 @@ func (q *statusEventsConsumer) add(e interface{}) {
 	q.cond.Broadcast()
 }
 
-func (q *statusEventsConsumer) eventLoop(consume func(e interface{})) {
+func (q *StatusEventsConsumer) eventLoop(consume func(e interface{})) {
 	for {
 		if e, ok := q.get(); ok {
 			consume(e)
@@ -70,7 +70,7 @@ func (q *statusEventsConsumer) eventLoop(consume func(e interface{})) {
 	}
 }
 
-func (q *statusEventsConsumer) get() (interface{}, bool) {
+func (q *StatusEventsConsumer) get() (interface{}, bool) {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
 

--- a/client/status_events.go
+++ b/client/status_events.go
@@ -34,13 +34,13 @@ func NewStatusEventsConsumer(size int) *StatusEventsConsumer {
 	return consumer
 }
 
-// start event delivery loop.
+// Start event delivery loop.
 func (q *StatusEventsConsumer) Start(consume func(e interface{})) {
 	q.closed = false
 	go q.eventLoop(consume)
 }
 
-// stop event delivery loop.
+// Stop event delivery loop.
 func (q *StatusEventsConsumer) Stop() {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
@@ -50,7 +50,7 @@ func (q *StatusEventsConsumer) Stop() {
 	q.cond.Broadcast()
 }
 
-// add new event to the queue.
+// Add new event to the queue.
 func (q *StatusEventsConsumer) Add(e interface{}) {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()

--- a/client/status_events_test.go
+++ b/client/status_events_test.go
@@ -24,8 +24,8 @@ func TestStatusEventsConsumerDelivery(t *testing.T) {
 	act := make([]interface{}, 0)
 	var wg sync.WaitGroup
 
-	statusEvents := newStatusEventsConsumer(count)
-	statusEvents.start(func(e interface{}) {
+	statusEvents := NewStatusEventsConsumer(count)
+	statusEvents.Start(func(e interface{}) {
 		act = append(act, e)
 		wg.Done()
 	})
@@ -34,7 +34,7 @@ func TestStatusEventsConsumerDelivery(t *testing.T) {
 
 	for i := 0; i < count; i++ {
 		wg.Add(1)
-		statusEvents.add(i)
+		statusEvents.Add(i)
 		exp[i] = i
 	}
 
@@ -44,14 +44,14 @@ func TestStatusEventsConsumerDelivery(t *testing.T) {
 }
 
 func TestStatusEventsConsumerAdd(t *testing.T) {
-	statusEvents := newStatusEventsConsumer(3)
-	statusEvents.start(func(e interface{}) {
+	statusEvents := NewStatusEventsConsumer(3)
+	statusEvents.Start(func(e interface{}) {
 		time.Sleep(2 * time.Second)
 	})
 
 	start := time.Now()
 	for i := 0; i < 10; i++ {
-		statusEvents.add(i)
+		statusEvents.Add(i)
 	}
 
 	elapsed := time.Since(start)
@@ -63,20 +63,20 @@ func TestStatusEventsConsumerAdd(t *testing.T) {
 
 func TestStatusEventsConsumerClose(t *testing.T) {
 	var counter int32
-	statusEvents := newStatusEventsConsumer(3)
-	statusEvents.start(func(e interface{}) {
+	statusEvents := NewStatusEventsConsumer(3)
+	statusEvents.Start(func(e interface{}) {
 		atomic.AddInt32(&counter, 1)
 	})
 
 	count := 5
 	for i := 0; i < count; i++ {
-		statusEvents.add("a")
+		statusEvents.Add("a")
 	}
 
-	statusEvents.stop()
+	statusEvents.Stop()
 
 	for i := 0; i < 10; i++ {
-		statusEvents.add("b")
+		statusEvents.Add("b")
 	}
 
 	time.Sleep(1 * time.Second)
@@ -92,8 +92,8 @@ func TestStatusEventsConsumerOrdering(t *testing.T) {
 	ls := make([]int, 0, count)
 
 	var wg sync.WaitGroup
-	statusEvents := newStatusEventsConsumer(count)
-	statusEvents.start(func(e interface{}) {
+	statusEvents := NewStatusEventsConsumer(count)
+	statusEvents.Start(func(e interface{}) {
 		ls = append(ls, e.(int))
 		wg.Done()
 	})
@@ -112,7 +112,7 @@ func TestStatusEventsConsumerOrdering(t *testing.T) {
 			defer m.Unlock()
 
 			counter++
-			statusEvents.add(counter)
+			statusEvents.Add(counter)
 		}()
 	}
 	latch.Add(-count)

--- a/client/uploadable.go
+++ b/client/uploadable.go
@@ -87,7 +87,7 @@ type AutoUploadable struct {
 
 	uidCounter int64
 
-	statusEvents *statusEventsConsumer
+	statusEvents *StatusEventsConsumer
 
 	uploads *Uploads
 
@@ -140,7 +140,7 @@ func NewAutoUploadable(uploadableCfg *UploadableConfig, handler UploadCustomizer
 	result.cfg = uploadableCfg
 	result.uidCounter = time.Now().Unix()
 
-	result.statusEvents = newStatusEventsConsumer(100)
+	result.statusEvents = NewStatusEventsConsumer(100)
 
 	result.state.Active = uploadableCfg.Active
 	result.state.StartTime = uploadableCfg.ActiveFrom.Time
@@ -179,7 +179,7 @@ func (u *AutoUploadable) Connect(mqttClient MQTT.Client, edgeCfg *EdgeConfigurat
 		logger.Error(err)
 	}
 
-	u.statusEvents.start(func(e interface{}) {
+	u.statusEvents.Start(func(e interface{}) {
 		u.UpdateProperty(lastUploadProperty, e)
 	})
 
@@ -188,7 +188,7 @@ func (u *AutoUploadable) Connect(mqttClient MQTT.Client, edgeCfg *EdgeConfigurat
 
 // Disconnect AutoUploadable from the Ditto endpoint and clean up used resources
 func (u *AutoUploadable) Disconnect() {
-	u.statusEvents.stop()
+	u.statusEvents.Stop()
 
 	u.client.Disconnect()
 	u.client.Unsubscribe()
@@ -337,7 +337,7 @@ func (u *AutoUploadable) uploadStatusUpdated(status *UploadStatus) {
 	}()
 
 	s := *status
-	u.statusEvents.add(s)
+	u.statusEvents.Add(s)
 }
 
 // ******* END UploadStatusListener methods *******//

--- a/client/uploads_test.go
+++ b/client/uploads_test.go
@@ -216,8 +216,8 @@ func TestUploadStatusOrder(t *testing.T) {
 	var lastUploadProgress int
 	u := AutoUploadable{}
 
-	u.statusEvents = newStatusEventsConsumer(100)
-	u.statusEvents.start(func(e interface{}) {
+	u.statusEvents = NewStatusEventsConsumer(100)
+	u.statusEvents.Start(func(e interface{}) {
 		status := e.(UploadStatus)
 		if status.Progress < lastUploadProgress {
 			wrongStatusMsg = fmt.Sprintf("Upload progress value decreased(%d -> %d)", status.Progress, lastUploadProgress)
@@ -238,7 +238,7 @@ func TestUploadStatusOrder(t *testing.T) {
 		}
 
 	})
-	defer u.statusEvents.stop()
+	defer u.statusEvents.Stop()
 
 	files := createTestFiles(t, 60, true, false)
 	defer cleanFiles(files)

--- a/flagparse/flags.go
+++ b/flagparse/flags.go
@@ -77,7 +77,7 @@ func ParseFlags(version string) (*UploadConfig, ConfigFileMissing) {
 	printVersion := flag.Bool("version", false, "Prints current version and exits")
 	configFile := flag.String(ConfigFile, "", "Defines the configuration file")
 
-	initFlagVars(flagsConfig, ConfigNames, nil)
+	InitFlagVars(flagsConfig, ConfigNames, nil)
 
 	flag.Parse()
 
@@ -87,8 +87,8 @@ func ParseFlags(version string) (*UploadConfig, ConfigFileMissing) {
 	}
 
 	config := &UploadConfig{}
-	warn := loadConfigFromFile(*configFile, config, ConfigNames, nil)
-	applyFlags(config, *flagsConfig)
+	warn := LoadConfigFromFile(*configFile, config, ConfigNames, nil)
+	ApplyFlags(config, *flagsConfig)
 
 	if *dumpFiles {
 		if config.Files == "" {
@@ -105,8 +105,8 @@ func ParseFlags(version string) (*UploadConfig, ConfigFileMissing) {
 	return config, warn
 }
 
-// applyFlags applies CLI values over config values
-func applyFlags(config interface{}, flagsConfig interface{}) {
+// ApplyFlags applies CLI values over config values
+func ApplyFlags(config interface{}, flagsConfig interface{}) {
 	srcVal := reflect.ValueOf(flagsConfig)
 	dstVal := reflect.ValueOf(config).Elem()
 	flag.Visit(func(f *flag.Flag) {
@@ -121,20 +121,20 @@ func applyFlags(config interface{}, flagsConfig interface{}) {
 	})
 }
 
-//initFlagVars parses the 'cfg' structure and defines flag variables for its fields.
+//InitFlagVars parses the 'cfg' structure and defines flag variables for its fields.
 //The 'cfg' parameter should be a pointer to structure. Flag names are taken from field names (with the first letter lower cased).
 //The 'names' parameter should be used for generating a strings.Replacer, replacing the keys(surrounded with {}) with their values.
 //The 'skip' parameter lists the flag names, that should not be parsed from configuration.
 //Flag descriptions are taken from 'descr' field tags, default values are taken from 'def' field tags
-func initFlagVars(cfg interface{}, names map[string]string, skip map[string]bool) {
+func InitFlagVars(cfg interface{}, names map[string]string, skip map[string]bool) {
 	initConfigValues(reflect.ValueOf(cfg).Elem(), names, skip, true)
 }
 
-//loadConfigFromFile loads the config from the specified file into the given config structure.
+//LoadConfigFromFile loads the config from the specified file into the given config structure.
 //The 'cfg' parameter should be a pointer to structure
 //The 'names' parameter should be used for generating a strings.Replacer, replacing the keys(surrounded with {}) with their values.
 //The 'skip' parameter lists the flag names, that should not be parsed from configuration.
-func loadConfigFromFile(configFile string, cfg interface{}, names map[string]string, skip map[string]bool) ConfigFileMissing {
+func LoadConfigFromFile(configFile string, cfg interface{}, names map[string]string, skip map[string]bool) ConfigFileMissing {
 	initConfigValues(reflect.ValueOf(cfg).Elem(), names, skip, false)
 
 	var warn ConfigFileMissing


### PR DESCRIPTION
[#33] Make status events and flag parsing functionality public

- StatusEventsConsumer and its functionalities are made public
- Several flag parsing functions are made public

Signed-off-by: Velitchko Valkov <Velitchko.Valkov@bosch.io>